### PR TITLE
redirect shorts view to "watch" view, block paths like /feed /gaming ...

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -37,6 +37,20 @@ const enableTheaterMode = () => {
   document.cookie = "wide=1; expires="+oneYearFromNow.toUTCString()+"; path=/; domain=.youtube.com"
 }
 
+const pathBlacklist = [
+  "/feed",
+  "/gaming",
+  "/reporthistory",
+]
+const isBlacklistedPath = (path) => {
+  for (const blacklistedPath of pathBlacklist) {
+    if (path.startsWith(blacklistedPath)) {
+      return true
+    }
+  }
+  return false
+}
+
 const initFY = () => {
   cleanUpFYClasses()
 
@@ -55,14 +69,12 @@ const initFY = () => {
   } else if (pathname === "/playlist") {
     // temporarily using the channel page to hide the side bar
     initChannelPage()
-  } else if (pathname === "/redirect") {
-    // do nothing
   } else if (pathname.startsWith("/shorts")) {
     // redirect shorts view to "watch" view
     const watch_url = window.location.href.replace("/shorts/","/watch?v=")
     window.location.replace(watch_url)
-  } else {
-    // redirect to home page, block paths like /feed/trending, /gaming, ...
+  } else if (isBlacklistedPath(pathname)) {
+    // redirect to home page
     window.location.replace("/")
   }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -50,6 +50,13 @@ const initFY = () => {
     initWatchPage()
   } else if (window.location.pathname.startsWith("/@") || window.location.pathname.startsWith("/channel")) {  // channel begins with /@ or /channel
     initChannelPage()
+  } else if (window.location.pathname.startsWith("/shorts")) {
+    // redirect shorts view to "watch" view
+    const watch_url = window.location.href.replace("/shorts/","/watch?v=")
+    window.location.replace(watch_url)
+  } else {
+    // redirect to home page, block paths like /feed/trending, /gaming, ...
+    window.location.replace("/")
   }
 }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -52,8 +52,11 @@ const initFY = () => {
     initWatchPage()
   } else if (pathname.startsWith("/@") || pathname.startsWith("/channel")) {  // channel begins with /@ or /channel
     initChannelPage()
-  } else if (pathname.startsWith("/playlist")) {
-    initChannelPage() // temporarily using the channel page to hide the side bar
+  } else if (pathname === "/playlist") {
+    // temporarily using the channel page to hide the side bar
+    initChannelPage()
+  } else if (pathname === "/redirect") {
+    // do nothing
   } else if (pathname.startsWith("/shorts")) {
     // redirect shorts view to "watch" view
     const watch_url = window.location.href.replace("/shorts/","/watch?v=")

--- a/src/extension.js
+++ b/src/extension.js
@@ -42,15 +42,19 @@ const initFY = () => {
 
   enableTheaterMode()
 
-  if (window.location.pathname === "/") {
+  const pathname = window.location.pathname
+
+  if (pathname === "/") {
     initHomePage()
-  } else if (window.location.pathname === "/results") {
+  } else if (pathname === "/results") {
     initResultsPage()
-  } else if (window.location.pathname === "/watch") {
+  } else if (pathname === "/watch") {
     initWatchPage()
-  } else if (window.location.pathname.startsWith("/@") || window.location.pathname.startsWith("/channel")) {  // channel begins with /@ or /channel
+  } else if (pathname.startsWith("/@") || pathname.startsWith("/channel")) {  // channel begins with /@ or /channel
     initChannelPage()
-  } else if (window.location.pathname.startsWith("/shorts")) {
+  } else if (pathname.startsWith("/playlist")) {
+    initChannelPage() // temporarily using the channel page to hide the side bar
+  } else if (pathname.startsWith("/shorts")) {
     // redirect shorts view to "watch" view
     const watch_url = window.location.href.replace("/shorts/","/watch?v=")
     window.location.replace(watch_url)


### PR DESCRIPTION
hi,
i really appreciate the work

i noticed shorts are still accessible with all the infinite scroll and also other pages like /feed/trending or /gaming
so i proposed these changes that work for me

have a look and let me know what you think

--
*update 1:
the last rule of redirecting to home seems a bit strict, but i think its ok
i added permission for `/playlist` and `/redirect`
and i checked out all the paths i can reach so nothing essential is blocked and redirected to home

these are some paths that can be distracting:
```
/reporthistory
/feed/history
/feed/trending
/feed/subscriptions
/gaming
```

these are misc:
```
/account
/about
/intl
/t
/ads
/creators
...
```

more paths can be seen here, tho i think they are not too relevant
https://www.youtube.com/sitemaps/sitemap.xml

--
*update 2:
commit 4
youtube is complicated and i probably dont know all the paths and apis
so i make a blacklist instead of the strict rule, redirecting all unspecified paths to home
the `/embed` path is essential