### PR TITLE
Fix recommendations flashing when changing screen

### DIFF
--- a/src/style-overrides.css
+++ b/src/style-overrides.css
@@ -362,7 +362,7 @@ body.fy-watch-page .button.yt-icon-button,
 body.fy-watch-page #guide-content,
 body.fy-watch-page #guide-button,
 body.fy-watch-page #sub-menu,
-body.fy-watch-page #related,
+#related,  /* Remove recommend sidebar. Don't target body.fy-watch-page because recommendations can flash onscreen when navigating to channel page */
 body.fy-watch-page #subscribe-button,
 body.fy-watch-page ytd-sentiment-bar-renderer,
 body.fy-watch-page .html5-endscreen, /* Remove suggested video endscreen */


### PR DESCRIPTION
- Issue: recommendations can flash on screen when clicking to navigate to the channel.
- Why: I believe it's because during this transition the `body.fy-watch-page` class is removed from the body, thus disabling the style
- Replicate:
1. Open a video
2. Open devtools
3. Disable internet. This makes it easier to stop and inspect the page. I created a new profile with 100% packet loss
4. Click the channel icon
5. Click the back arrow. This stops loading
6. Execute `debugger` to make sure nothing changes

![image](https://github.com/user-attachments/assets/3c391504-8b4a-426d-a8df-6bf579281488)
