### PR TITLE
Add rtl support to logo menu

### DIFF
--- a/src/style-overrides.css
+++ b/src/style-overrides.css
@@ -61,6 +61,11 @@ body {
   padding-top: 8px;
 }
 
+body[dir='rtl'] .fy-logo-menu {
+  left: unset;
+  right: 16px;
+}
+
 .fy-home-page .fy-logo-menu {
   left: 0;
   bottom: 0;


### PR DESCRIPTION
When youtube is rtl, the logo menu should show on the right instead of left side of the screen.

<img width="578" height="561" alt="Screenshot 2025-09-23 at 08 11 06" src="https://github.com/user-attachments/assets/1271c56b-4a35-4171-adfe-491a8e7c9a72" />
