### PR TITLE
Remove invisible sidebar from the front of the logo menu

### DIFF
--- a/src/style-overrides.css
+++ b/src/style-overrides.css
@@ -326,6 +326,11 @@ body.fy-results-page #primary #header /* Hides empty div before search results *
   display: none !important;
 }
 
+/* Remove invisible div that prevents the logo menu from staying open.  */
+tp-yt-app-drawer {
+  display: none !important;
+}
+
 /* START Position search bar filters on the right side from search results. */
 body.fy-results-page ytd-search #header {
   max-width: 800px !important; /* Align search result width with header */


### PR DESCRIPTION
This PR removes an invisible element from the front of the logo menu that prevents the menu from staying open. This bug occurs on:

- Watch history Page
- Playlists Page 
- Watch later Page
- Liked videos Page


| Occurence | Element |
|----------|----------|
| <img width="297" height="612" alt="image" src="https://github.com/user-attachments/assets/50dcea1f-432e-440c-b23c-0555de975ca3" />| <img width="310" height="620" alt="image" src="https://github.com/user-attachments/assets/8d1afd26-808f-45c9-a792-942dd151ffd9" />  |


